### PR TITLE
Update shader_bytecode.h to fix return warning

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -86,6 +86,10 @@ struct SourceRegister {
             return value - 0x10;
         else if (GetRegisterType() == RegisterType::FloatUniform)
             return value - 0x20;
+        else {
+            // TODO: Should throw an exception or something.
+        }
+        return -1;
     }
 
     static const SourceRegister FromTypeAndIndex(RegisterType type, int index) {


### PR DESCRIPTION
Fixed /shader_bytecode.h:89:5: warning: control reaches end of non-void function [-Wreturn-type]